### PR TITLE
Daily: Who on your team can roll back production? (GitLaunch alpha invite)

### DIFF
--- a/content/daily/who-can-roll-back-production.md
+++ b/content/daily/who-can-roll-back-production.md
@@ -1,0 +1,86 @@
+---
+date: 2026-07-27T14:00:00.000Z
+title: "Who on your team can roll back production?"
+description: "For years I've written to you about deployment frequency and MTTR. Then I went and built the thing. The GitLaunch alpha is opening."
+category: daily
+rss: true
+---
+
+Hello there! 👋
+
+A question I ask every team I coach:
+
+**What is running in production right now?**
+
+Not what you merged. Not what the pipeline said an hour ago.
+
+What is *actually live*, this second.
+
+Watch what happens next. Someone opens Slack. Someone scrolls CI logs. Someone squints at a git SHA and says "I think that's the one."
+
+Then I ask the harder question:
+
+**If it breaks, who can roll it back?**
+
+On most lean teams, the honest answer is one person.
+
+And that person is not always awake.
+
+---
+
+I've written to you about this for years.
+
+Deploy daily instead of weekly, so changes stay small. Watch your faulty deployment rate. Restore service fast — [high performers roll back in under five minutes, with one button](https://edgardocarreras.com/daily/mean-time-to-recover).
+
+I kept saying *one button*.
+
+And then I'd walk into a team and ask: okay — where is it? Who's allowed to press it?
+
+Nobody had one. Or one person did, and it lived on their laptop, in their head, behind a script only they had ever run.
+
+The practice was right. The button didn't exist.
+
+So I built it.
+
+---
+
+It's called **GitLaunch**.
+
+It is not another CI/CD tool. Keep your GitHub Actions. Keep your Jenkins. Nothing to rip out.
+
+GitLaunch starts where your pipeline ends — with the part nobody owns.
+
+One board shows every build across every environment. What's on staging. What's live. What's ready to promote.
+
+And anyone on the team can move it. QA. Your PM. Your product owner. Promote to the next environment, or roll back to the last good build, in one click.
+
+No YAML. No kubectl. No platform team.
+
+Two DORA numbers you already care about are exactly the two this is built to move:
+
+**Lead time**, because code-complete to live no longer waits on the one person who can deploy.
+
+**MTTR**, because undo becomes a click instead of a war room.
+
+Deploy day stops being a ritual to dread. It gets boring.
+
+Boring is the goal.
+
+---
+
+GitLaunch is almost ready, and I'm opening a small alpha — inviting people in waves.
+
+If your team ships regularly, and deploys are bottlenecked on one or two people, I'd genuinely love to have you in early.
+
+**→ [Join the alpha waitlist](https://gitlaunch.dev/?utm_source=newsletter&utm_medium=email&utm_campaign=alpha-launch&utm_content=daily-alpha-invite)**
+
+Yours,
+Ed
+
+---
+
+PS:
+
+Even if you never touch the product, hit reply and tell me one thing: the last time something broke in production, how did your team find out what was live, and who fixed it?
+
+I'm reading every one of those. They're shaping what I build next.

--- a/content/daily/who-can-roll-back-production.md
+++ b/content/daily/who-can-roll-back-production.md
@@ -30,11 +30,11 @@ And that person is not always awake.
 
 I've written to you about this for years.
 
-Deploy daily instead of weekly, so changes stay small. Watch your faulty deployment rate. Restore service fast — [high performers roll back in under five minutes, with one button](https://edgardocarreras.com/daily/mean-time-to-recover).
+Deploy daily instead of weekly, so changes stay small. Watch your faulty deployment rate. Restore service fast. [High performers roll back in under five minutes, with one button](https://edgardocarreras.com/daily/mean-time-to-recover).
 
 I kept saying *one button*.
 
-And then I'd walk into a team and ask: okay — where is it? Who's allowed to press it?
+And then I'd walk into a team and ask: okay, where is it? Who's allowed to press it?
 
 Nobody had one. Or one person did, and it lived on their laptop, in their head, behind a script only they had ever run.
 
@@ -48,7 +48,7 @@ It's called **GitLaunch**.
 
 It is not another CI/CD tool. Keep your GitHub Actions. Keep your Jenkins. Nothing to rip out.
 
-GitLaunch starts where your pipeline ends — with the part nobody owns.
+GitLaunch starts where your pipeline ends. The part nobody owns.
 
 One board shows every build across every environment. What's on staging. What's live. What's ready to promote.
 
@@ -68,7 +68,7 @@ Boring is the goal.
 
 ---
 
-GitLaunch is almost ready, and I'm opening a small alpha — inviting people in waves.
+GitLaunch is almost ready, and I'm opening a small alpha. I'm inviting people in waves.
 
 If your team ships regularly, and deploys are bottlenecked on one or two people, I'd genuinely love to have you in early.
 


### PR DESCRIPTION
Adds one daily-newsletter post announcing the **GitLaunch alpha** to the daily list.

**Post:** `content/daily/who-can-roll-back-production.md` — "Who on your team can roll back production?"
**Scheduled:** `2026-07-27T14:00:00.000Z` (Monday, same 14:00Z slot every post in the series uses)

## Why this angle

Written straight off the [positioning canvas](https://github.com/donedgardo/launchpad) (`docs/positioning/positioning-canvas.html`), so it doesn't invent claims:

- Leads with the canvas **lead fear** — _"we can't say what's actually live right now, and only one person can roll it back"_ — not a feature list.
- Explicitly refuses the **CI/CD tool** shelf ("Keep your GitHub Actions. Keep your Jenkins.") and sits on the **"deployment control anyone can drive"** shelf.
- Hits all three fears in canvas order: blindness → bus-factor → slow rollback.
- Names the two DORA metrics GitLaunch moves (**lead time**, **MTTR**) — which is already this list's vocabulary.
- Says **"no platform team"**, the canvas segment marker.

It also earns the pitch instead of dropping it cold: the post opens on the coaching question Ed already asks teams, links back to the existing [MTTR daily](https://edgardocarreras.com/daily/mean-time-to-recover) where he wrote "roll back in under five minutes, one button," and then makes the point that the practice was right but the button didn't exist — so he built it.

## Campaign link (`/campaign-url`)

```
https://gitlaunch.dev/?utm_source=newsletter&utm_medium=email&utm_campaign=alpha-launch&utm_content=daily-alpha-invite
```

`source=newsletter · medium=email · campaign=alpha-launch · content=daily-alpha-invite`

Follows the convention in launchpad `docs/marketing/README.md`. Verified: returns **200**.

**New register row, deliberately.** The existing `newsletter / referral / founder-network` row is the one-off founder-network blast; this daily list is a different audience (agile practitioners and delivery leads) with a different hypothesis, so it gets its own `utm_content` rather than muddying that referral baseline. `medium=email` is used because a newsletter send is literally an email placement per the README's vocabulary.

✅ **Register row added:** the matching `docs/marketing/CAMPAIGNS.md` row is in donedgardo/launchpad#36, which satisfies the README's "add a row before you send a link" rule. Merge that before this send goes out.

## Secondary goal

The PS asks readers to reply with the story of their last production break — who found out what was live, who fixed it. That feeds the canvas's own next move (_"interview 5–10 of your happiest users… real positioning is discovered in their language"_) and the interview journal, which currently has one bucket-D entry against a target of 8–12.

## Conventions followed

- Frontmatter matches the recent series: `date` / `title` / `description` / `category: daily` / `rss: true`
- Absolute URLs throughout (email compatibility — same reason as commits `8c179b4` and `bd8260c`)
- Voice matched to the March 2026 series: `Hello there! 👋` opener, single-sentence paragraphs, `Yours,\nEd`, PS with the ask
- No raw `<` or `{` in the body (MDX-safe); 427 words, in range for the list

## Notes

- Link is **not** shortened — a TinyURL in a newsletter body hurts deliverability and hides the destination. Say the word if you'd rather have a short link.
- Not built locally (fresh clone, no `node_modules`); validated by parsing the frontmatter, checking for MDX-breaking characters, and confirming both outbound links resolve 200.
